### PR TITLE
Unify Query Tool strings

### DIFF
--- a/ckanext/querytool/templates/querytool/admin/base_edit_data.html
+++ b/ckanext/querytool/templates/querytool/admin/base_edit_data.html
@@ -7,10 +7,10 @@
 
 {% set ctrl = 'ckanext.querytool.controllers.querytool:QueryToolController' %}
 
-{% block subtitle %}{{ _('Query Tool Manage') }}{% endblock %}
+{% block subtitle %}{{ _('Manage Query Data') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Query Tool'), controller=ctrl, action='list' %}</li>
+  <li>{% link_for _('Queries'), controller=ctrl, action='list' %}</li>
 {% endblock %}
 
 {% block page_header %}

--- a/ckanext/querytool/templates/querytool/admin/base_edit_visualizations.html
+++ b/ckanext/querytool/templates/querytool/admin/base_edit_visualizations.html
@@ -6,10 +6,10 @@
 
 {% set ctrl = 'ckanext.querytool.controllers.querytool:QueryToolController' %}
 
-{% block subtitle %}{{ _('Query Tool Manage Visualisations') }}{% endblock %}
+{% block subtitle %}{{ _('Manage Query Visualisations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Query Tools'), controller=ctrl, action='list' %}</li>
+  <li>{% link_for _('Queries'), controller=ctrl, action='list' %}</li>
 {% endblock %}
 
 {% block page_header %}

--- a/ckanext/querytool/templates/querytool/admin/base_show.html
+++ b/ckanext/querytool/templates/querytool/admin/base_show.html
@@ -2,12 +2,11 @@
 
 {% set ctrl = 'ckanext.querytool.controllers.querytool:QueryToolController' %}
 
-{% block subtitle %}{{ _('Query Tools') }}{% endblock %}
+{% block subtitle %}{{ _('Queries') }}{% endblock %}
 
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Query Tools'), controller=ctrl, action='list' %}</li>
-  <li class="active">{% link_for _('Nekoj query tool'), controller=ctrl, action='list' %}</li>
+  <li>{% link_for _('Queries'), controller=ctrl, action='list' %}</li>
 {% endblock %}
 
 {% block page_header %}

--- a/ckanext/querytool/templates/querytool/admin/snippets/edit_data_form.html
+++ b/ckanext/querytool/templates/querytool/admin/snippets/edit_data_form.html
@@ -55,11 +55,11 @@ Example usage:
 
   {% set dataset_resources = h.querytool_get_dataset_resources(data.dataset_name) %}
   {% block querytool_choose_chart_resource %}
-    {{ form.select('chart_resource', label=_('Choose resource for chart'), options=dataset_resources, selected=data.chart_resource, error=error) }}
+    {{ form.select('chart_resource', label=_('Chart resource'), options=dataset_resources, selected=data.chart_resource, error=error) }}
   {% endblock %}
 
   {% block querytool_choose_map_resource %}
-    {{ form.select('map_resource', label=_('Choose resource for map'), options=dataset_resources, selected=map_resource, error=error) }}
+    {{ form.select('map_resource', label=_('Map resoure'), options=dataset_resources, selected=map_resource, error=error) }}
   {% endblock %}
 
   {% block querytool_main_filters %}

--- a/ckanext/querytool/templates/querytool/admin/snippets/stages.html
+++ b/ckanext/querytool/templates/querytool/admin/snippets/stages.html
@@ -6,9 +6,9 @@
 
 <ol class="stages {{ class }}">
   <li class="first {{ s1 }}">
-    <span class="highlight">{{ _('Manage data') }}</span>
+    <span class="highlight">{{ _('Query data') }}</span>
   </li>
   <li class="last {{ s2 }}">
-    <span class="highlight">{{ _('Manage visualisations') }}</span>
+    <span class="highlight">{{ _('Query visualisations') }}</span>
   </li>
 </ol>


### PR DESCRIPTION
This PR replaces existing 'Query Tool' strings and uses just 'Query' instead. Additionally, the following two strings have also been updated.

* Choose resource for chart -> Chart resource
* Choose resource for map -> Map resource

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix