### PR TITLE
Cast response header as string

### DIFF
--- a/ckanext/querytool/controllers/querytool.py
+++ b/ckanext/querytool/controllers/querytool.py
@@ -467,4 +467,9 @@ class QueryToolController(base.BaseController):
 
         file_name = name
 
+        response.headerlist = \
+            [('Content-Type', resp_format),
+             ('Content-Disposition',
+              str('attachment;filename=' + file_name + '.' + file_format))]
+
         return resp


### PR DESCRIPTION
Attachment file name is cast to string to avoid Unicode errors.



### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes bugfix

Please [X] all the boxes above that apply
