### PR TITLE
Update .btn-chart-download icon

### DIFF
--- a/ckanext/querytool/templates/querytool/public/read.html
+++ b/ckanext/querytool/templates/querytool/public/read.html
@@ -114,7 +114,7 @@
         y_label = item.y_label
         %}
         <a class="btn-chart-download">
-          <i class="fa fa-download fa-lg" aria-hidden="true" title="{{ _('Download image') }}" data-name="{{ item.title }}"></i>
+          <i class="fa fa-picture-o fa-lg" aria-hidden="true" title="{{ _('Download image') }}" data-name="{{ item.title }}"></i>
         </a>
       </div>
       {% endfor %}


### PR DESCRIPTION
This PR replaces the chart image download icon.

### Proposed fixes:

- Update icon from `fa-download` to `fa-picture-o`

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
