### PR TITLE
Remove extra bracket in templates/querytool/public/base_main.html

### DIFF
--- a/ckanext/querytool/templates/querytool/public/base_main.html
+++ b/ckanext/querytool/templates/querytool/public/base_main.html
@@ -11,7 +11,7 @@
             {% block page_header_inner_content %}
               {% block page_header_icon %}{% endblock %}
               {% block page_header_title %}<h1>Welcome</h1>{% endblock %}
-              {% block page_header_description %}<p class="desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse ut lectus at erat tincidunt   pellentesque ut quis lorem. In varius nunc in lorem blandit, at finibus risus lobortis. Nulla ac ipsum in felis consequat pretium sit amet eget mi. Nulla   congue commodo velit, non ultrices magna hendrerit sed.</p>{% endblock %}>
+              {% block page_header_description %}<p class="desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse ut lectus at erat tincidunt   pellentesque ut quis lorem. In varius nunc in lorem blandit, at finibus risus lobortis. Nulla ac ipsum in felis consequat pretium sit amet eget mi. Nulla   congue commodo velit, non ultrices magna hendrerit sed.</p>{% endblock %}
             {% endblock %}
           </div>
         </div>


### PR DESCRIPTION
Removes extra bracket in templates/querytool/public/base_main.html after the `.page-header` closing tag. 

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
