### PR TITLE
Revert image download icon regression

### DIFF
--- a/ckanext/querytool/templates/querytool/public/read.html
+++ b/ckanext/querytool/templates/querytool/public/read.html
@@ -113,7 +113,7 @@
             y_label = item.y_label
             %}
          <a class="btn-chart-download">
-          <i class="fa fa-download fa-lg" aria-hidden="true" title="{{ _('Download image') }}" data-name="{{ item.title }}"></i>
+          <i class="fa fa-picture-o fa-lg" aria-hidden="true" title="{{ _('Download image') }}" data-name="{{ item.title }}"></i>
         </a>
         {% endif %}
         {% if item.type == 'text_box' %}


### PR DESCRIPTION
This PR fixes the image download icon regression.

### Proposed fixes:

- `fa-download` -> `fa-picture-o`


### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
