### PR TITLE
Add missing CSS class of .filter-item

### DIFF
--- a/ckanext/querytool/templates/ajax_snippets/public_filter_item.html
+++ b/ckanext/querytool/templates/ajax_snippets/public_filter_item.html
@@ -11,7 +11,7 @@
   <div class="filter-group">
     <label for="data_filter_value_{{ id }}">{{ selected_filter.alias }}</label>
     <input type="hidden" id="data_filter_name_{{ id }}" name="{{alias}}data_filter_name_{{ n }}" value="{{ selected_filter.name }}"/>
-    <select class="filter-item filter-item-value {{ class }}" id="data_filter_value_{{ id }}" name="{{alias}}data_filter_value_{{ n }}">
+    <select class="filter-item filter-item-value input-block-level {{ class }}" id="data_filter_value_{{ id }}" name="{{alias}}data_filter_value_{{ n }}">
       <option value="">&mdash; Select value &mdash;</option>
       {% if selected_filter %}
       <option value="{{ selected_filter.value }}" selected>{{ selected_filter.value }}</option>

--- a/ckanext/querytool/templates/querytool/public/snippets/public_chart_filter.html
+++ b/ckanext/querytool/templates/querytool/public/snippets/public_chart_filter.html
@@ -2,7 +2,7 @@
   <div class="filter-group">
     <label for="chart_filter_value_{{ id }}">{{ alias }}</label>
     <input type="hidden" id="chart_filter_name_{{ id }}" name="{{q_name}}_chart_filter_name_{{ n }}" value="{{ name }}"/>
-    <select class="filter-item filter-item-value" id="chart_filter_value_{{ id }}" name="{{q_name}}_chart_filter_value_{{ n }}">
+    <select class="filter-item filter-item-value input-block-level" id="chart_filter_value_{{ id }}" name="{{q_name}}_chart_filter_value_{{ n }}">
       <option value="{{ value }}" selected>{{ value }}</option>
     </select>
     <input type="hidden" id="chart_filter_resource_{{ id }}" value="{{ resource_id }}"/>


### PR DESCRIPTION
This PR adds missing CSS class on the `<select>` element, that acts as an inline filter for the charts.

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
