### PR TITLE
Add last-dragged-element's id to window.location after dragging

### DIFF
--- a/ckanext/querytool/fanstatic/javascript/visualizations_settings.js
+++ b/ckanext/querytool/fanstatic/javascript/visualizations_settings.js
@@ -206,6 +206,7 @@
             el.querySelector('.grippy').classList.remove('cursor-grabbing');
 
             handleItemsOrder();
+            window.location.hash = el.id;
         });
 
         // This function updates the order numbers for the form elements.


### PR DESCRIPTION
This PR sets window.location.hash to the last-dragged-element's id, when dragging is complete. That helps to keep dragged element in view.

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
