### PR TITLE
Fix rename

### DIFF
--- a/ckanext/querytool/logic/action/update.py
+++ b/ckanext/querytool/logic/action/update.py
@@ -36,6 +36,18 @@ def querytool_update(context, data_dict):
         raise toolkit.ValidationError(errors)
 
     querytool = CkanextQueryTool.get(name=data_dict['querytool'])
+    visualizations = CkanextQueryToolVisualizations.get(name=data_dict['querytool'])
+
+    # if name is not changed don't insert in visualizations table
+    is_changed = False
+    if visualizations:
+        is_changed = (querytool.name == visualizations.name)
+
+    if visualizations and is_changed:
+        visualizations.name = data.get('name')
+        visualizations.save()
+        session.add(querytool)
+        session.commit()
 
     if not querytool:
         querytool = CkanextQueryTool()

--- a/ckanext/querytool/logic/action/update.py
+++ b/ckanext/querytool/logic/action/update.py
@@ -36,7 +36,8 @@ def querytool_update(context, data_dict):
         raise toolkit.ValidationError(errors)
 
     querytool = CkanextQueryTool.get(name=data_dict['querytool'])
-    visualizations = CkanextQueryToolVisualizations.get(name=data_dict['querytool'])
+    visualizations = \
+        CkanextQueryToolVisualizations.get(name=data_dict['querytool'])
 
     # if name is not changed don't insert in visualizations table
     is_changed = False


### PR DESCRIPTION
This PR's fixes issue when administrator change the name of the querytool and change is not added in the visualizations.



### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes bugfix

Please [X] all the boxes above that apply
