### PR TITLE
Remove maps option from filters page

### DIFF
--- a/ckanext/querytool/controllers/querytool.py
+++ b/ckanext/querytool/controllers/querytool.py
@@ -138,6 +138,7 @@ class QueryToolController(base.BaseController):
             _querytool = {}
 
         if toolkit.request.method == 'POST' and not data:
+
             data = dict(toolkit.request.POST)
             filters = []
             y_axis_columns = []

--- a/ckanext/querytool/fanstatic/javascript/querytool_data.js
+++ b/ckanext/querytool/fanstatic/javascript/querytool_data.js
@@ -281,7 +281,6 @@
 
         var datasetField = $('#field-datasets');
         var chartResourceSelect = $('#chart_resource');
-        var mapResourceSelect = $('#map_resource');
         var yAxisColumnsResults = $('#y-axis-columns-results');
         var yAxisColumnsNotice = $('#y-axis-columns-notice');
         var yAxisColumnsContainer = $('#y-axis-columns-container');
@@ -391,10 +390,7 @@
         function get_dataset_resources(dataset_name) {
 
             chartResourceSelect.attr('disabled', 'true');
-            mapResourceSelect.attr('disabled', 'true');
-
             chartResourceSelect.empty();
-            mapResourceSelect.empty();
 
             api.get('package_show', {
                     id: dataset_name
@@ -409,16 +405,11 @@
                     });
 
                     chartResourceSelect.removeAttr('disabled');
-                    mapResourceSelect.removeAttr('disabled');
-
                     chartResourceSelect.append($('<option></option>').attr('value', '').text('-- Choose resource --'));
-                    mapResourceSelect.append($('<option></option>').attr('value', '').text('-- Choose resource --'));
 
                     $.each(dataset_resources, function(i, res) {
                         var name = res.name || 'Unnamed resource';
                         chartResourceSelect.append($('<option></option>')
-                            .attr('value', res.id).text(name));
-                        mapResourceSelect.append($('<option></option>')
                             .attr('value', res.id).text(name));
                     });
                 });

--- a/ckanext/querytool/logic/action/update.py
+++ b/ckanext/querytool/logic/action/update.py
@@ -55,7 +55,7 @@ def querytool_update(context, data_dict):
 
     items = ['title', 'description', 'name', 'private', 'type', 'dataset_name',
              'filters', 'sql_string', 'related_querytools',
-             'map_resource', 'chart_resource',
+             'chart_resource',
              'y_axis_columns']
     for item in items:
         setattr(querytool, item, data.get(item))

--- a/ckanext/querytool/logic/schema.py
+++ b/ckanext/querytool/logic/schema.py
@@ -28,7 +28,6 @@ def querytool_schema():
         'related_querytools': [ignore_missing, unicode],
         'created': [ignore_missing, isodate],
         'modified': [ignore_missing, isodate],
-        'map_resource': [not_empty, unicode],
         'chart_resource': [not_empty, unicode],
         'y_axis_columns': [not_empty, unicode],
     }

--- a/ckanext/querytool/model.py
+++ b/ckanext/querytool/model.py
@@ -111,8 +111,6 @@ def define_query_tool_table():
                                     default=u''),
                              Column('dataset_name', types.UnicodeText,
                                     nullable=False),
-                             Column('map_resource', types.UnicodeText,
-                                    nullable=False),
                              Column('chart_resource', types.UnicodeText,
                                     nullable=False),
                              Column('filters', types.UnicodeText,

--- a/ckanext/querytool/templates/querytool/admin/snippets/edit_data_form.html
+++ b/ckanext/querytool/templates/querytool/admin/snippets/edit_data_form.html
@@ -103,9 +103,6 @@ Example usage:
     {{ form.select('chart_resource', label=_('Chart resource'), options=dataset_resources, selected=data.chart_resource, error=errors.chart_resource, attrs={'required': 'required'}) }}
   {% endblock %}
 
-  {% block querytool_choose_map_resource %}
-    {{ form.select('map_resource', label=_('Map resoure'), options=dataset_resources, selected=map_resource, error=errors.map_resource, attrs={'required': 'required'}) }}
-  {% endblock %}
 
   <legend>{{ _('Y Axis columns') }}</legend>
   {% set columns = h.querytool_get_resource_columns(data.chart_resource) %}


### PR DESCRIPTION
Code and functionalities for maps on filters page is removed, because we are using it in visualizations.



### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes bugfix

Please [X] all the boxes above that apply
