### PR TITLE
Process public query description through Markdown

### DIFF
--- a/ckanext/querytool/templates/querytool/public/read.html
+++ b/ckanext/querytool/templates/querytool/public/read.html
@@ -19,7 +19,7 @@
       {% endblock %}
       {% block page_header_description %}
       {% if querytools[0].description %}
-        <p class="desc">{{ querytools[0].description }}</p>
+        <p class="desc">{{ h.render_markdown(querytools[0].description) }}</p>
       {% endif %}
       {% endblock %}
     </div>


### PR DESCRIPTION
This PR processes the public query description string through Markdown, before printing. Markdown conversion ignores inlined HTML tags and only supports Markdown formatting.

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
