### PR TITLE
Fix save validation

### DIFF
--- a/ckanext/querytool/controllers/querytool.py
+++ b/ckanext/querytool/controllers/querytool.py
@@ -386,16 +386,12 @@ class QueryToolController(base.BaseController):
                         data['map_size_{}'.format(id)]
 
                     maps.append(map_item)
-                    print map_item
 
-            if any(visualizations):
-                vis = visualizations + text_boxes + images + maps
-                _visualization_items['visualizations'] = json.dumps(vis)
+            vis = visualizations + text_boxes + images + maps
+            _visualization_items['visualizations'] = json.dumps(vis)
+            if visualizations:
                 _visualization_items['y_axis_column'] =\
                     visualizations[0].get('y_axis')
-
-            else:
-                _visualization_items['visualizations'] = ''
 
             try:
                 junk = _get_action('querytool_visualizations_update',

--- a/ckanext/querytool/fanstatic/javascript/visualizations_settings.js
+++ b/ckanext/querytool/fanstatic/javascript/visualizations_settings.js
@@ -114,9 +114,9 @@
         var map_resource = vizForm.data('mapResource');
         var chooseYAxisColumn = $('#choose_y_axis_column');
 
-        var charts = $('.chart_field');
+        var viz_item = $('.item');
         // Only disable Save button if there aren't visualizations
-        if (charts.length === 0) {
+        if (viz_item.length === 0) {
             $('#save-visualization-btn').attr('disabled', 'true');
         }
 
@@ -134,6 +134,7 @@
         //delete dynamicly created textbox section
         $(document).on('click', '.delete-item-btn', function(el) {
             el.target.closest('.item').remove();
+            enableSave();
         });
 
         var createVisualization = $('#add-visualization-btn');
@@ -164,13 +165,12 @@
                     })
                     .done(function(data) {
                         var item = visualizationItems.prepend(data);
-                        $('#save-visualization-btn').attr('disabled', false);
                         ckan.module.initializeElement(item.find('div[data-module=querytool-viz-preview]')[0]);
                         handleRenderedChartFilters(items);
                         handleItemsOrder();
-
                         var axisY = $('[name*=chart_field_axis_y_]');
                         axisY.val(axisYValue);
+                        enableSave();
                     });
             } else if (visualization === 'map') {
                 ckan.sandbox().client.getTemplate('map_fields.html', {
@@ -181,7 +181,7 @@
                         var item = visualizationItems.prepend(data);
                         ckan.module.initializeElement(item.find('div[data-module=querytool_map]')[0]);
                         handleItemsOrder();
-
+                        enableSave();
                     });
             } else if (visualization == 'text-box') {
                 ckan.sandbox().client.getTemplate('text_box_item.html', {
@@ -190,7 +190,7 @@
                     .done(function(data) {
                         var item = visualizationItems.prepend(data);
                         handleItemsOrder();
-
+                        enableSave();
                     });
             } else if (visualization === 'image') {
                 ckan.sandbox().client.getTemplate('image_item.html', {
@@ -200,8 +200,8 @@
                         var item = visualizationItems.prepend(data);
                         handleImageItems(items);
                         handleItemsOrder();
+                        enableSave();
                     });
-
             }
 
         });
@@ -220,6 +220,13 @@
             window.location.hash = el.id;
             window.scrollTo(0, el.offsetTop);
         });
+
+        //enable or disable save button
+        function enableSave(){
+            var isEmpty = $('#visualization-settings-items').find('.item');
+            var isDisabled = (isEmpty.length >= 1);
+            $('#save-visualization-btn').attr('disabled', !isDisabled);
+        }
 
         // This function updates the order numbers for the form elements.
         function handleItemsOrder() {

--- a/ckanext/querytool/templates/ajax_snippets/chart_item.html
+++ b/ckanext/querytool/templates/ajax_snippets/chart_item.html
@@ -212,7 +212,7 @@
       <input type="hidden" id="chart_field_axis_y_{{ n }}" name="chart_field_axis_y_{{ n }}" {% if chart %} value="{{ chart.y_axis }}" {% endif %} />
 
       <ul class="inline text-right chart-actions">
-        <li class="remove"><a class="btn delete-chart-btn">{% block delete_button_text %}<span class="fa fa-trash-o" aria-hidden="true"></span> {{ _('Delete') }}{% endblock %}</a></li>
+        <li class="remove"><a class="btn delete-item-btn">{% block delete_button_text %}<span class="fa fa-trash-o" aria-hidden="true"></span> {{ _('Delete') }}{% endblock %}</a></li>
         <li><a class="btn update-chart-btn"><span class="fa fa-refresh" aria-hidden="true"></span> {{ _('Update') }}</a></li>
       </ul>
 

--- a/ckanext/querytool/templates/querytool/admin/snippets/edit_visualizations_form.html
+++ b/ckanext/querytool/templates/querytool/admin/snippets/edit_visualizations_form.html
@@ -31,7 +31,6 @@
       <li><button id="save-visualization-btn" type="submit" class="btn btn-success" name="save">{{ _('Save') }}</button></li>
     </ul>
   </legend>
-
   {% if data.visualizations %}
     {% set selected_y_axis_column = data.y_axis_column %}
   {% endif %}


### PR DESCRIPTION
Administrator now can create different type of visualizations without required charts. Also, bug where admin can delete visualizations and save state is fixed.



### Features:

- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X includes bugfix

Please [X] all the boxes above that apply
