### PR TITLE
Rename chart size to image size

### DIFF
--- a/ckanext/querytool/templates/ajax_snippets/image_item.html
+++ b/ckanext/querytool/templates/ajax_snippets/image_item.html
@@ -1,10 +1,10 @@
 <div id="image_item_{{ n }}" class="item image_item visualization-fields-section">
-  <div class="item-wrapper">
-        {% snippet 'querytool/admin/snippets/image_upload.html', data=data,n=n  %}
-   <ul class="inline text-right chart-actions">
-      <li class="remove"><a id="delete-textbox-btn" class="btn delete-item-btn">{% block delete_button_text %}<span class="fa fa-trash-o" aria-hidden="true"></span> {{ _('Delete') }}{% endblock %}</a></li>
-   </ul>
-   <input type="hidden" id="image_upload_{{ n }}" name="image_upload_{{ n }}" value="{{ image_upload }}"/>
-   <span class="grippy"></span>
-  </div>
+   <div class="item-wrapper">
+      {% snippet 'querytool/admin/snippets/image_upload.html', data=data,n=n  %}
+      <ul class="inline text-right chart-actions">
+         <li class="remove"><a id="delete-textbox-btn" class="btn delete-item-btn">{% block delete_button_text %}<span class="fa fa-trash-o" aria-hidden="true"></span> {{ _('Delete') }}{% endblock %}</a></li>
+      </ul>
+      <input type="hidden" id="image_upload_{{ n }}" name="image_upload_{{ n }}" value="{{ image_upload }}"/>
+      <span class="grippy"></span>
+   </div>
 </div>

--- a/ckanext/querytool/templates/querytool/admin/snippets/edit_visualizations_form.html
+++ b/ckanext/querytool/templates/querytool/admin/snippets/edit_visualizations_form.html
@@ -1,5 +1,4 @@
 {% import 'macros/form.html' as form %}
-
 {% resource 'querytool/vendor/c3/c3.css' %}
 {% resource 'querytool/vendor/d3/d3.js' %}
 {% resource 'querytool/vendor/c3/c3.js' %}

--- a/ckanext/querytool/templates/querytool/admin/snippets/image_upload.html
+++ b/ckanext/querytool/templates/querytool/admin/snippets/image_upload.html
@@ -5,20 +5,19 @@ n - Order of the item
 Example usage:
 {% snippet 'querytool/admin/snippets/image_upload.html', data=data,n=order  %}
 #}
-
 {% set uploads_enabled = h.uploads_enabled() %}
 {% if data %}
-   {% set n =  data.order | string %}
-   {% set media_type =  data.media_type %}
-   {% set image_url =  data.url %}
-   {% set media_image_url = 'media_image_url_' + n %}
-   {% set media_image_upload = 'media_image_upload_' + n %}
-   {% set media_clear_upload = 'media_clear_upload_' + n %}
-   {% set is_upload = image_url and not image_url.startswith('http') %}
-   {% set is_url = image_url and image_url.startswith('http') %}
-   {% set data_module = 'image-upload' %}
+{% set n =  data.order | string %}
+{% set media_type =  data.media_type %}
+{% set image_url =  data.url %}
+{% set media_image_url = 'media_image_url_' + n %}
+{% set media_image_upload = 'media_image_upload_' + n %}
+{% set media_clear_upload = 'media_clear_upload_' + n %}
+{% set is_upload = image_url and not image_url.startswith('http') %}
+{% set is_url = image_url and image_url.startswith('http') %}
+{% set data_module = 'image-upload' %}
 {% else %}
-   {% set data_module = 'custom-image-upload' %}
+{% set data_module = 'custom-image-upload' %}
 {% endif %}
 {% if uploads_enabled %}
 <div
@@ -53,7 +52,7 @@ Example usage:
 {% endif %}
 {% set sizes = h.querytool_get_visualization_size() %}
 <div class="control-group control-select">
-   <label class="control-label" for="image_field_size_{{ n }}">{{ _('Chart size') }}</label>
+   <label class="control-label" for="image_field_size_{{ n }}">{{ _('Image size') }}</label>
    <div class="controls ">
       <select id="image_field_size_{{ n }}" name="image_field_size_{{ n }}">
       {% for size in sizes %}


### PR DESCRIPTION
Chart size is renamed to image size in image visualization.



### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [X] includes bugfix

Please [X] all the boxes above that apply
