### PR TITLE
Remove image size validation

### DIFF
--- a/ckanext/querytool/controllers/querytool.py
+++ b/ckanext/querytool/controllers/querytool.py
@@ -363,7 +363,7 @@ class QueryToolController(base.BaseController):
                                                     .format(
                                                         id),
                                                     'False')
-                            upload.upload(uploader.get_max_image_size())
+                            upload.upload(uploader)
                             image_url = upload.filename
 
                         image['url'] = image_url


### PR DESCRIPTION
Image size validation is removed, now bigger images can be uploaded.



### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
