### PR TITLE
Format % and rounded values

### DIFF
--- a/ckanext/querytool/fanstatic/javascript/modules/viz-preview.js
+++ b/ckanext/querytool/fanstatic/javascript/modules/viz-preview.js
@@ -172,8 +172,15 @@ ckan.module('querytool-viz-preview', function() {
                         return tooltip_name + ' ' +  d;
                     }
             }
-            options.tooltip.format['value'] = function (value, ratio, id) {
-                var format =  d3.format(data_format);
+             options.tooltip.format['value'] = function (value, ratio, id) {
+                var format = '';
+                if(data_format ===  ','){
+                    format = !(value % 1) ? d3.format(data_format) : d3.format(',.2f');
+                }else if(data_format === '.0%'){
+                    format = !(value % 1) ? d3.format(data_format) : d3.format('.2%');
+                }else{
+                   format =  d3.format(data_format);
+                }
                 return format(value);
             }
 
@@ -215,7 +222,17 @@ ckan.module('querytool-viz-preview', function() {
                     y: {
                         tick: {
                           count: tick_count,
-                          format: d3.format(y_tick_format),
+                          format: function (value) {
+                                    var format = '';
+                                    if(y_tick_format ===  ','){
+                                        format = !(value % 1) ? d3.format(y_tick_format) : d3.format(',.2f');
+                                    }else if(data_format === '.0%'){
+                                        format = !(value % 1) ? d3.format(y_tick_format) : d3.format('.2%');
+                                    }else{
+                                       format =  d3.format(y_tick_format);
+                                    }
+                                     return format(value);
+                        },
                           rotate: yrotate
                          },
                          padding: {
@@ -295,17 +312,37 @@ ckan.module('querytool-viz-preview', function() {
                     type: ctype,
                     labels: show_labels
                 };
-
                 if(show_labels){
                     options.data['labels'] =  {
-                        format:  d3.format(data_format)
+                        format:   function (value) {
+                            //TODO: ADD this in one function
+                            var format = '';
+                            if(data_format ===  ','){
+                                format = !(value % 1) ? d3.format(data_format) : d3.format(',.2f');
+                            }else if(data_format === '.0%'){
+                                format = !(value % 1) ? d3.format(data_format) : d3.format('.2%');
+                            }else{
+                               format =  d3.format(data_format);
+                            }
+                             return format(value);
+                        }
                     }
                 }
                 options.axis = {
                     y: {
                         tick: {
                           count: tick_count,
-                          format: d3.format(y_tick_format),
+                          format: function (value) {
+                            var format = '';
+                            if(y_tick_format ===  ','){
+                                format = !(value % 1) ? d3.format(y_tick_format) : d3.format(',.2f');
+                            }else if(y_tick_format === '.0%'){
+                                format = !(value % 1) ? d3.format(y_tick_format) : d3.format('.2%');
+                            }else{
+                               format =  d3.format(y_tick_format);
+                            }
+                             return format(value);
+                        },
                           rotate: yrotate
                         },
                     padding: {
@@ -475,6 +512,6 @@ ckan.module('querytool-viz-preview', function() {
                         }
                     });
                 }
-        }
+        },
     }
 });

--- a/ckanext/querytool/fanstatic/javascript/modules/viz-preview.js
+++ b/ckanext/querytool/fanstatic/javascript/modules/viz-preview.js
@@ -173,16 +173,9 @@ ckan.module('querytool-viz-preview', function() {
                     }
             }
              options.tooltip.format['value'] = function (value, ratio, id) {
-                var format = '';
-                if(data_format ===  ','){
-                    format = !(value % 1) ? d3.format(data_format) : d3.format(',.2f');
-                }else if(data_format === '.0%'){
-                    format = !(value % 1) ? d3.format(data_format) : d3.format('.2%');
-                }else{
-                   format =  d3.format(data_format);
-                }
-                return format(value);
-            }
+                 var dataf = this.sortData(data_format, value);
+                 return dataf;
+            }.bind(this);
 
             if (this.options.chart_type === 'donut' ||
                 this.options.chart_type === 'pie') {
@@ -223,16 +216,9 @@ ckan.module('querytool-viz-preview', function() {
                         tick: {
                           count: tick_count,
                           format: function (value) {
-                                    var format = '';
-                                    if(y_tick_format ===  ','){
-                                        format = !(value % 1) ? d3.format(y_tick_format) : d3.format(',.2f');
-                                    }else if(data_format === '.0%'){
-                                        format = !(value % 1) ? d3.format(y_tick_format) : d3.format('.2%');
-                                    }else{
-                                       format =  d3.format(y_tick_format);
-                                    }
-                                     return format(value);
-                        },
+                            var dataf = this.sortData(y_tick_format, value);
+                            return dataf;
+                        }.bind(this),
                           rotate: yrotate
                          },
                          padding: {
@@ -315,17 +301,9 @@ ckan.module('querytool-viz-preview', function() {
                 if(show_labels){
                     options.data['labels'] =  {
                         format:   function (value) {
-                            //TODO: ADD this in one function
-                            var format = '';
-                            if(data_format ===  ','){
-                                format = !(value % 1) ? d3.format(data_format) : d3.format(',.2f');
-                            }else if(data_format === '.0%'){
-                                format = !(value % 1) ? d3.format(data_format) : d3.format('.2%');
-                            }else{
-                               format =  d3.format(data_format);
-                            }
-                             return format(value);
-                        }
+                           var dataf = this.sortData(data_format, value);
+                            return dataf;
+                        }.bind(this),
                     }
                 }
                 options.axis = {
@@ -333,16 +311,9 @@ ckan.module('querytool-viz-preview', function() {
                         tick: {
                           count: tick_count,
                           format: function (value) {
-                            var format = '';
-                            if(y_tick_format ===  ','){
-                                format = !(value % 1) ? d3.format(y_tick_format) : d3.format(',.2f');
-                            }else if(y_tick_format === '.0%'){
-                                format = !(value % 1) ? d3.format(y_tick_format) : d3.format('.2%');
-                            }else{
-                               format =  d3.format(y_tick_format);
-                            }
-                             return format(value);
-                        },
+                            var dataf = this.sortData(y_tick_format, value);
+                            return dataf;
+                        }.bind(this),
                           rotate: yrotate
                         },
                     padding: {
@@ -513,5 +484,18 @@ ckan.module('querytool-viz-preview', function() {
                     });
                 }
         },
+
+        //Check data format, if % or comma round decimal numbers
+        sortData: function(dataf, val){
+            var format = '';
+            if(dataf ===  ','){
+                format = !(val % 1) ? d3.format(dataf) : d3.format(',.2f');
+            }else if(dataf === '.0%'){
+                format = !(val % 1) ? d3.format(dataf) : d3.format('.2%');
+            }else{
+               format =  d3.format(dataf);
+            }
+             return format(val);
+        }
     }
 });


### PR DESCRIPTION
The formats “comma (thousands separator)” and “percent %” are limited to show only two decimals (if the value has decimals)



### Features:

- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
